### PR TITLE
Fix/add note csv and resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [0.2.1] - 2024-09-24
+
+* **Improved `resume` behavior:**
+    * If no notes are provided, it will attempt to retrieve them from the last tracked task.
+* **Enhanced `export_sheet` functionality:**
+    * A new `notes` column has been added to the exported CSV file.
+* **Minor bug fixes:**
+    * Resolved issues related to resuming tasks with notes and deleting items.
+
+
 ## [0.2.0] - 2024-09-24
 
 * **Improved code quality:**

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timet (0.2.0)
+    timet (0.2.1)
       sqlite3 (~> 2, >= 1.7)
       thor (~> 1.2)
       tty-prompt (~> 0.2)

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -15,9 +15,10 @@ module Timet
 
     desc "start [tag] --notes='...'", "start time tracking  --notes='my notes...'"
     option :notes, type: :string, desc: 'Add a note'
-    def start(tag)
+    def start(tag, notes = nil)
       start = Time.now.to_i
-      @db.insert_item(start, tag, options[:notes]) if %i[no_items complete].include?(@db.last_item_status)
+      notes = options[:notes] || notes
+      @db.insert_item(start, tag, notes) if %i[no_items complete].include?(@db.last_item_status)
       summary
     end
 
@@ -36,8 +37,10 @@ module Timet
     def resume
       if @db.last_item_status == :incomplete
         puts 'A task is currently being tracked.'
-      elsif (last_task = @db.last_item&.[](3))
-        start last_task
+      elsif @db.last_item.any?
+        tag = @db.last_item[3]
+        notes = @db.last_item[4]
+        start(tag, notes)
       end
     end
 

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -57,7 +57,7 @@ module Timet
       item = @db.find_item(id)
       return puts "No tracked time found for id: #{id}" unless item
 
-      TimeReport.new(@db, nil, nil).row(item)
+      TimeReport.new(@db, nil, nil, nil).show_row(item)
       return unless TTY::Prompt.new.yes?('Are you sure you want to delete this entry?')
 
       delete_item_and_print_message(id, "Deleted #{id}")

--- a/lib/timet/time_report.rb
+++ b/lib/timet/time_report.rb
@@ -31,7 +31,7 @@ module Timet
       total
     end
 
-    def row(item)
+    def show_row(item)
       format_table_header
       display_time_entry(item)
       puts format_table_separator
@@ -64,7 +64,7 @@ module Timet
       date if idx.zero? || date != TimeHelper.timestamp_to_date(last_start_date)
     end
 
-    def display_time_entry(item, date)
+    def display_time_entry(item, date = nil)
       return puts 'Missing time entry data.' unless item
 
       id, start_time_value, end_time_value, tag_name, notes = item

--- a/lib/timet/time_report.rb
+++ b/lib/timet/time_report.rb
@@ -39,18 +39,17 @@ module Timet
     end
 
     def export_sheet
-      header = %w[ID Start End Tag]
-
       CSV.open("#{filename}.csv", 'w') do |csv|
-        csv << header
+        csv << %w[ID Start End Tag Notes]
 
-        items.each do |row|
-          # Convert start and end times from timestamps to ISO 8601 format
-          start_time = Time.at(row[1]).strftime('%Y-%m-%d %H:%M:%S')
-          end_time = Time.at(row[2]).strftime('%Y-%m-%d %H:%M:%S')
-
-          # Write the row with formatted times
-          csv << [row[0], start_time, end_time, row[3]]
+        items.each do |id, start_time, end_time, tags, notes|
+          csv << [
+            id,
+            TimeHelper.format_time(start_time),
+            TimeHelper.format_time(end_time),
+            tags,
+            notes
+          ]
         end
       end
     end

--- a/lib/timet/version.rb
+++ b/lib/timet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Timet
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/timet/application_spec.rb
+++ b/spec/timet/application_spec.rb
@@ -136,11 +136,11 @@ RSpec.describe Timet::Application do
         allow(db).to receive(:last_item).and_return([1, 1_727_191_918, 1_727_191_923, 'task_name', nil])
         allow(application).to receive(:start)
         application.resume
-        expect(application).to have_received(:start).with('task_name')
+        expect(application).to have_received(:start).with('task_name', nil)
       end
 
       it 'does not call start if there is no last task' do
-        allow(db).to receive(:last_item).and_return(nil)
+        allow(db).to receive(:last_item).and_return([])
         allow(application).to receive(:start)
         application.resume
         expect(application).not_to have_received(:start)

--- a/spec/timet/application_spec.rb
+++ b/spec/timet/application_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Timet::Application do
       before do
         allow(db).to receive(:find_item).with(1).and_return(item)
         allow(Timet::TimeReport).to receive(:new).and_return(time_report)
-        allow(time_report).to receive(:row)
+        allow(time_report).to receive(:show_row)
         allow(db).to receive(:delete_item)
       end
 
@@ -170,7 +170,7 @@ RSpec.describe Timet::Application do
         allow(TTY::Prompt).to receive(:new).and_return(prompt)
         allow(prompt).to receive(:yes?).and_return(true)
         application.delete(1)
-        expect(time_report).to have_received(:row).with(item)
+        expect(time_report).to have_received(:show_row).with(item)
       end
 
       it "outputs 'Deleted 1' when the user confirms deletion" do


### PR DESCRIPTION
##  Enhanced `resume` and `export_sheet`, Added Notes Support

### Description

This pull request introduces several enhancements to the `timet` application:

* **Improved `resume` behavior:**
    * If no notes are provided, it will attempt to retrieve them from the last tracked task.
* **Enhanced `export_sheet` functionality:**
    * A new `notes` column has been added to the exported CSV file.
* **Minor bug fixes:**
    * Resolved issues related to resuming tasks with notes and deleting items.
