### PR TITLE
Remove byebug from Gemfile and related dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.8.1] - 2024-10-02
+**Bug fixes:**
+  - Fixed a LoadError caused by the byebug gem being required after its removal.
+
 ## [0.8.0] - 2024-10-01
 
 **Improvements:**

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'thor', '~> 1.3'
 gem 'tty-prompt', '~> 0.23.1'
 
 group :development do
-  gem 'byebug', '~> 11.1.3'
   gem 'rubocop', '~> 1.65'
   gem 'rubocop-rspec', '~> 3.1', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timet (0.8.0)
+    timet (0.8.1)
       sqlite3 (~> 2, >= 1.7)
       thor (~> 1.2)
       tty-prompt (~> 0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    byebug (11.1.3)
     csv (3.3.0)
     diff-lcs (1.5.1)
     docile (1.4.1)
@@ -97,7 +96,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  byebug (~> 11.1.3)
   csv (~> 3.3.0)
   rake (~> 13.2)
   rspec (~> 3.13)

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -6,7 +6,6 @@ require 'tty-prompt'
 require_relative 'validation_edit_helper'
 require_relative 'application_helper'
 require_relative 'time_helper'
-require 'byebug'
 
 module Timet
   # Application class that defines CLI commands for time tracking:

--- a/lib/timet/version.rb
+++ b/lib/timet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Timet
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end

--- a/spec/timet/time_report_spec.rb
+++ b/spec/timet/time_report_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../helpers'
-require 'byebug'
 
 RSpec.describe Timet::TimeReport do
   let(:db) do


### PR DESCRIPTION
### Description:
Remove the `byebug` gem from the project as it is no longer needed. This change includes updating the `Gemfile`, `Gemfile.lock`, and removing the `byebug` require statement in the application code.

---
### Improvements:
- [x] Simplified the development dependencies by removing the `byebug` gem.

---
### Bug fixes:
- [x] Fixed a `LoadError` caused by the `byebug` gem being required after its removal.

---
#### Tasks:
- [x] Remove the `byebug` gem from the `Gemfile`.
- [x] Update the `Gemfile.lock` to reflect the removal of the `byebug` gem and its dependencies.
- [x] Remove the `require 'byebug'` statement in `lib/timet/application.rb`.

### Additional Considerations:
