### PR TITLE
Enhanced/allow optional parameters edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## [Unreleased]
 
+## [0.8.2] - 2024-10-02
+
+**Improvements:**
+- Added optional field and new_value parameters to the edit command.
+- Updated the edit method logic to prompt for field and new_value if they are not provided.
+- Enhanced test coverage to include scenarios where field and new_value are provided directly and when they are not.
+- Updated the README to reflect the new features of the edit command, including both interactive and direct specification modes.
+
+**Additional Considerations:**
+- The changes ensure that the edit command is more versatile and user-friendly, catering to both interactive users and those who prefer scripting or automation.
+
 ## [0.8.1] - 2024-10-02
 **Bug fixes:**
   - Fixed a LoadError caused by the byebug gem being required after its removal.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timet (0.8.1)
+    timet (0.8.2)
       sqlite3 (~> 2, >= 1.7)
       thor (~> 1.2)
       tty-prompt (~> 0.2)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ gem install timet
     ```
 
 
-- **timet edit**: It allows users update a task's notes, tag, start or end fields. 
+- **timet edit**: It allows users to update a task's notes, tag, start, or end fields. Users can either interactively select the field and provide a new value or specify them directly in the command.
+
+- **Interactive Mode:**
     ```bash
     timet e 1
     ```
@@ -112,6 +114,26 @@ gem install timet
       Start
       End
     ```
+
+
+- **Direct Specification Mode:**
+    ```bash
+    timet e 1 notes "New Meeting Notes"
+    ```
+
+    ```
+    Tracked time report [today]:
+    +-------+------------+--------+----------+----------+----------+--------------------------+
+    | Id    | Date       | Tag    | Start    | End      | Duration | Notes                    |
+    +-------+------------+--------+----------+----------+----------+--------------------------+
+    |     2 | 2024-08-09 | task1  | 16:15:07 |        - | 00:00:00 | Meeting with client      |
+    |     1 |            | task1  | 14:55:07 | 15:55:07 | 01:00:00 | New Meeting Note         |
+    +-------+------------+--------+----------+----------+----------+--------------------------+
+    |                                           Total:  | 01:00:00 |                          |
+    +-------+------------+--------+----------+----------+----------+--------------------------+
+    ```
+
+
 
 ## Command Reference
 

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -87,7 +87,8 @@ module Timet
       end
     end
 
-    desc 'edit (e) [id]', 'edit a task'
+    desc 'edit (e) [id] [field] [value]',
+         'edit a task, [field] (notes, tag, start or end) and [value] are optional parameters'
     def edit(id, field = nil, new_value = nil)
       item = @db.find_item(id)
       return puts "No tracked time found for id: #{id}" unless item

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -88,13 +88,16 @@ module Timet
     end
 
     desc 'edit (e) [id]', 'edit a task'
-    def edit(id)
+    def edit(id, field = nil, new_value = nil)
       item = @db.find_item(id)
       return puts "No tracked time found for id: #{id}" unless item
 
       display_item(item)
-      field = select_field_to_edit
-      new_value = prompt_for_new_value(item, field)
+      unless FIELD_INDEX.keys.include?(field&.downcase) || new_value
+        field = select_field_to_edit
+        new_value = prompt_for_new_value(item, field)
+      end
+
       validate_and_update(item, field, new_value)
 
       summary.display

--- a/lib/timet/version.rb
+++ b/lib/timet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Timet
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end

--- a/spec/timet/application_spec.rb
+++ b/spec/timet/application_spec.rb
@@ -248,6 +248,8 @@ RSpec.describe Timet::Application do
       allow(TTY::Prompt).to receive(:new).and_return(prompt)
       allow(prompt).to receive_messages(select: 'Notes', ask: 'new_notes')
       allow(app).to receive(:summary)
+      allow(app).to receive_messages(select_field_to_edit: 'notes', prompt_for_new_value: 'new_notes')
+      allow(db).to receive(:update_item)
     end
 
     context 'when item is found' do
@@ -255,9 +257,20 @@ RSpec.describe Timet::Application do
         allow(db).to receive(:find_item).and_return(item)
       end
 
-      it 'updates the item with new value' do
-        app.edit('1')
-        expect(db).to have_received(:update_item).with(1, 'notes', 'new_notes')
+      context 'when field and new_value are provided' do
+        it 'updates the item with new value' do
+          app.edit('1', 'notes', 'new_notes')
+          expect(db).to have_received(:update_item).with(1, 'notes', 'new_notes')
+        end
+      end
+
+      context 'when field and new_value are not provided' do
+        it 'prompts for field and new value and updates the item' do
+          app.edit('1')
+          expect(app).to have_received(:select_field_to_edit)
+          expect(app).to have_received(:prompt_for_new_value).with(item, 'notes')
+          expect(db).to have_received(:update_item).with(1, 'notes', 'new_notes')
+        end
       end
     end
 


### PR DESCRIPTION
### Description:
This pull request enhances the edit command in the Timet::Application class by making it more flexible and user-friendly. The edit command now accepts optional field and new_value parameters, allowing users to specify the field and new value directly when calling the command. This reduces the need for interactive prompts in certain scenarios and makes the command more convenient for scripting or automation.

---
### Improvements:
- Added optional field and new_value parameters to the edit command.
- Updated the edit method logic to prompt for field and new_value if they are not provided.
- Enhanced test coverage to include scenarios where field and new_value are provided directly and when they are not.
- Updated the README to reflect the new features of the edit command, including both interactive and direct specification modes.

---
### Bug fixes:
- [ ]
---
#### Tasks:
- [ ] 

### Additional Considerations:
-  The changes ensure that the edit command is more versatile and user-friendly, catering to both interactive users and those who prefer scripting or automation.
