### PR TITLE
Update command descriptions and handle nil updated_item in display_item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+## [0.9.2] - 2024-10-06
+
+**Improvements:**
+- Improved the description of the 'start' command to clarify the usage of optional notes.
+
+**Bug fixes:**
+- Modified the 'display_item' method to handle cases where 'updated_item' is nil, ensuring that the original 'item' is displayed instead.
+
+
 ## [0.9.1] - 2024-10-04
 
 **Improvements:**

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timet (0.9.1)
+    timet (0.9.2)
       sqlite3 (~> 2, >= 1.7)
       thor (~> 1.2)
       tty-prompt (~> 0.2)

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -35,7 +35,7 @@ module Timet
 
     VALID_STATUSES_FOR_INSERTION = %i[no_items complete].freeze
 
-    desc "start [tag] --notes=''", "start time tracking  --notes='my notes...'"
+    desc "start [tag] --notes='[notes]'", 'Start time tracking for a specific tag with optional notes'
     option :notes, type: :string, desc: 'Add a note'
     # Starts a new tracking session with the given tag and optional notes.
     #
@@ -178,7 +178,7 @@ module Timet
       end
 
       updated_item = validate_and_update(item, field, new_value)
-      display_item(updated_item)
+      display_item(updated_item || item)
     end
 
     desc 'delete (d) [id]', 'delete a task'

--- a/lib/timet/version.rb
+++ b/lib/timet/version.rb
@@ -7,5 +7,5 @@ module Timet
   #
   # @example Get the version of the Timet application
   #   Timet::VERSION # => '0.9.1'
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 end


### PR DESCRIPTION
### Description:
This pull request addresses improvements in the command descriptions and fix nil values in the `display_item` method.

---
### Improvements:
- [x] Improved the description of the 'start' command to clarify the usage of optional notes.

---
### Bug fixes:
- [x] Modified the 'display_item' method to handle cases where 'updated_item' is nil, ensuring that the original 'item' is displayed instead.

---
#### Tasks:
- [x] Review and update command descriptions for clarity.
- [x] Implement nil value handling in the `display_item` method.

