### PR TITLE
Add version command and update executables in gemspec to add tt alias

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timet (1.0.0)
+    timet (1.1.0)
       sqlite3 (~> 2, >= 1.7)
       thor (~> 1.2)
       tty-prompt (~> 0.2)
@@ -34,7 +34,7 @@ GEM
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)

--- a/README.md
+++ b/README.md
@@ -39,14 +39,20 @@ gem install timet
 
 ## Usage
 
-- timet start [tag] --notes="" --pomodoro=[minutes]**: Starts tracking time for a task labeled with the provided [tag],  notes and "pomodoro time" in minutes (optional). Example:
+### Command Aliases
+
+- `timet`: The primary command for interacting with the Timet application.
+- `tt`: An alias for the `timet` command, providing a shorter alternative.
+
+---
+- **timet start [tag] --notes="" --pomodoro=[minutes]**: Starts tracking time for a task labeled with the provided [tag],  notes and "pomodoro time" in minutes (optional). Example:
 
   ```bash
   timet start task1 --notes="Meeting with client" --pomodoro=25
 
   or
 
-  timet start task1 "Meeting with client" 25
+  tt start task1 "Meeting with client" 25
   ```
 
   ```
@@ -110,7 +116,7 @@ gem install timet
 - **Interactive Mode:**
 
   ```bash
-  timet e 1
+  timet edit 1
   ```
 
   ```

--- a/bin/tt
+++ b/bin/tt
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/timet'
+
+Timet::Application.start(ARGV)

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -245,6 +245,18 @@ module Timet
       true
     end
 
+    #   Displays the current version of the Timet gem.
+    #
+    #   @example
+    #     $ timet version
+    #     1.0.0
+    #
+    #   @return [void] This method does not return a value; it prints the version to the standard output.
+    desc 'version', 'version'
+    def version
+      puts Timet::VERSION
+    end
+
     private
 
     # Deletes a tracking item from the database by its ID and prints a confirmation message.

--- a/lib/timet/version.rb
+++ b/lib/timet/version.rb
@@ -6,6 +6,6 @@ module Timet
   # @return [String] The version number in the format 'major.minor.patch'.
   #
   # @example Get the version of the Timet application
-  #   Timet::VERSION # => '1.0.0'
-  VERSION = '1.0.0'
+  #   Timet::VERSION # => '1.1.0'
+  VERSION = '1.1.0'
 end

--- a/timet.gemspec
+++ b/timet.gemspec
@@ -32,7 +32,8 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = "bin"
-  spec.executables = ["timet"]
+  spec.executables << "timet"
+  spec.executables << "tt"
   spec.require_paths = ["lib"]
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
### Description:
This pull request introduces several updates to the Timet application, including the addition of a new `version` command, the introduction of an alias `tt` for the `timet` command, and updates to the gem version and dependencies.

---
### Improvements:
- [x] Added a new `version` command to display the current version of the Timet gem.
- [x] Introduced an alias `tt` for the `timet` command, providing a shorter alternative.
- [x] Updated the README to include the `tt` alias and provide examples for both `timet` and `tt` commands.
- [x] Updated the gem version to `1.1.0`.
- [x] Added the `tt` executable to the gemspec.
- [x] Updated the `rspec-mocks` dependency to version `3.13.2`.

---
### Bug fixes:
- [ ] No bug fixes in this PR.

---
#### Tasks:
- [x] Update `Gemfile.lock` to reflect the new gem version and updated dependencies.
- [x] Add the `tt` executable script to the `bin` directory.
- [x] Update the `version` command in `lib/timet/application.rb` with Yardoc documentation.
- [x] Update the `VERSION` constant in `lib/timet/version.rb` to `1.1.0`.
- [x] Update the `timet.gemspec` to include the `tt` executable.
- [x] Update the README to reflect the new `tt` alias and provide examples for both `timet` and `tt` commands.

