### PR TITLE
Enhancement/export icalendar format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ gemspec
 
 gem 'csv', '~> 3.3.0'
 gem 'descriptive_statistics', '~> 2.5'
-gem 'icalendar'
+gem 'icalendar', '~> 2.10.3'
 gem 'rake', '~> 13.2'
-gem 'sqlite3', '~> 2.1.0'
+gem 'sqlite3', '~> 2.2'
 gem 'thor', '~> 1.3'
 gem 'tty-prompt', '~> 0.23.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 gem 'csv', '~> 3.3.0'
 gem 'descriptive_statistics', '~> 2.5'
+gem 'icalendar'
 gem 'rake', '~> 13.2'
 gem 'sqlite3', '~> 2.1.0'
 gem 'thor', '~> 1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,11 +18,11 @@ GEM
       ice_cube (~> 0.16)
       ostruct
     ice_cube (0.17.0)
-    json (2.7.4)
+    json (2.8.1)
     language_server-protocol (3.17.0.3)
     ostruct (0.6.0)
     parallel (1.26.3)
-    parser (3.3.5.0)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     pastel (0.8.0)
@@ -44,7 +44,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.67.0)
+    rubocop (1.68.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -54,7 +54,7 @@ GEM
       rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.3)
+    rubocop-ast (1.34.0)
       parser (>= 3.3.1.0)
     rubocop-rspec (3.2.0)
       rubocop (~> 1.61)
@@ -65,16 +65,16 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
-    sqlite3 (2.1.1-aarch64-linux-gnu)
-    sqlite3 (2.1.1-aarch64-linux-musl)
-    sqlite3 (2.1.1-arm-linux-gnu)
-    sqlite3 (2.1.1-arm-linux-musl)
-    sqlite3 (2.1.1-arm64-darwin)
-    sqlite3 (2.1.1-x86-linux-gnu)
-    sqlite3 (2.1.1-x86-linux-musl)
-    sqlite3 (2.1.1-x86_64-darwin)
-    sqlite3 (2.1.1-x86_64-linux-gnu)
-    sqlite3 (2.1.1-x86_64-linux-musl)
+    sqlite3 (2.2.0-aarch64-linux-gnu)
+    sqlite3 (2.2.0-aarch64-linux-musl)
+    sqlite3 (2.2.0-arm-linux-gnu)
+    sqlite3 (2.2.0-arm-linux-musl)
+    sqlite3 (2.2.0-arm64-darwin)
+    sqlite3 (2.2.0-x86-linux-gnu)
+    sqlite3 (2.2.0-x86-linux-musl)
+    sqlite3 (2.2.0-x86_64-darwin)
+    sqlite3 (2.2.0-x86_64-linux-gnu)
+    sqlite3 (2.2.0-x86_64-linux-musl)
     thor (1.3.2)
     tty-color (0.6.0)
     tty-cursor (0.7.1)
@@ -90,30 +90,30 @@ GEM
     wisper (2.0.1)
 
 PLATFORMS
-  aarch64-linux
+  aarch64-linux-gnu
   aarch64-linux-musl
-  arm-linux
+  arm-linux-gnu
   arm-linux-musl
   arm64-darwin
-  x86-linux
+  x86-linux-gnu
   x86-linux-musl
   x86_64-darwin
-  x86_64-linux
+  x86_64-linux-gnu
   x86_64-linux-musl
 
 DEPENDENCIES
   csv (~> 3.3.0)
   descriptive_statistics (~> 2.5)
-  icalendar
+  icalendar (~> 2.10.3)
   rake (~> 13.2)
   rspec (~> 3.13)
   rubocop (~> 1.67)
   rubocop-rspec (~> 3.2)
   simplecov (~> 0.22)
-  sqlite3 (~> 2.1.0)
+  sqlite3 (~> 2.2)
   thor (~> 1.3)
   timet!
   tty-prompt (~> 0.23.1)
 
 BUNDLED WITH
-   2.5.17
+   2.5.18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timet (1.4.2)
+    timet (1.4.3)
       sqlite3 (~> 2, >= 1.7)
       thor (~> 1.2)
       tty-prompt (~> 0.2)
@@ -14,8 +14,13 @@ GEM
     descriptive_statistics (2.5.1)
     diff-lcs (1.5.1)
     docile (1.4.1)
+    icalendar (2.10.3)
+      ice_cube (~> 0.16)
+      ostruct
+    ice_cube (0.17.0)
     json (2.7.4)
     language_server-protocol (3.17.0.3)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
@@ -99,6 +104,7 @@ PLATFORMS
 DEPENDENCIES
   csv (~> 3.3.0)
   descriptive_statistics (~> 2.5)
+  icalendar
   rake (~> 13.2)
   rspec (~> 3.13)
   rubocop (~> 1.67)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - **Block Time Plot:** Visualizes the distribution of tracked time across a specified range of dates. Each column represents the amount of time tracked during a specific hour, with a header showing the hours and a row for each date displaying the time blocks for each hour.
 - **Tag Distribution Plot:** Illustrates the proportion of total tracked time allocated to each tag, showing the relative contribution of each tag to the overall time tracked.
 - **Detailed Statistics:** Displays detailed statistics for each tag, including total duration, average duration, and standard deviation.
+- **iCalendar Export:** Easily export your time tracking data to iCalendar format for integration with calendar applications.
 
 **Examples:**
 
@@ -181,7 +182,8 @@ gem install timet
 | `timet summary yesterday (y)`                | Display a report of tracked time for yesterday.                             | `timet su y`                      |
 | `timet summary week (w)`                     | Display a report of tracked time for the week.                              | `timet su w`                      |
 | `timet summary month (m)`                    | Display a report of tracked time for the month.                             | `timet su m`                      |
-| `timet su t --csv=[filename]`                | Display a report of tracked time for today and export it to `filename.csv`. | `timet su t --csv=file.csv`       |
+| `timet su t --csv=[filename]`                | Display a report of tracked time for today and export to CSV file | `timet su t --csv=file.csv`       |
+| `timet su w --ics=[filename]`                | Display a report of tracked time for week and export to iCalendar file | `timet su w --ics=file.csv`       |
 | `timet delete [id]`                          | Delete a task by its ID.                                                    | `timet d [id]`                    |
 | `timet cancel`                               | Cancel active time tracking.                                                | `timet c`                         |
 | `timet edit [id]`                            | Update a task's notes, tag, start, or end fields.                           | `timet e [id]`                    |

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -162,17 +162,19 @@ module Timet
     #
     # @note The method initializes a `TimeReport` object with the database, time_scope, tag, and optional CSV filename.
     # @note The method calls `display` on the `TimeReport` object to show the summary.
-    # @note If a CSV filename is provided and there are items to export, the method calls `export_sheet` to export the
+    # @note If a CSV filename is provided and there are items to export, the method calls `export_csv` to export the
     # summary to a CSV file.
     # @note If no items are found to export, it prints a message indicating that no items were found.
     def summary(time_scope = nil, tag = nil)
       csv_filename = options[:csv]&.split('.')&.first
-      report = TimeReport.new(@db, time_scope, tag, csv_filename)
+      ics_filename = options[:ics]&.split('.')&.first
+      report = TimeReport.new(@db, time_scope, tag, csv_filename, ics_filename)
 
       report.display
       items = report.items
-      if csv_filename && items.any?
-        report.export_sheet
+      if items.any?
+        report.export_csv if csv_filename
+        report.export_icalendar if ics_filename
       elsif items.empty?
         puts 'No items found to export'
       end

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -142,42 +142,18 @@ module Timet
     option :csv, type: :string, desc: 'Export to CSV'
     option :ics, type: :string, desc: 'Export to iCalendar'
     # Generates a summary of tracking items based on the provided time_scope and tag, and optionally exports the summary
-    # to a CSV file.
+    # to a CSV file and/or an iCalendar file.
     #
-    # @param time_scope [String, nil] The time_scope to apply when generating the summary. Possible values include
-    # 'today', 'yesterday', 'week', 'month', or a date range in the format '[start_date]..[end_date]'.
-    # @param tag [String, nil] The tag to time_scope the tracking items by.
+    # @param time_scope [String, nil] The filter to apply when fetching items. Possible values include 'today',
+    #   'yesterday', 'week', 'month', or a date range in the format 'YYYY-MM-DD..YYYY-MM-DD'.
+    # @param tag [String, nil] The tag to filter the items by.
     #
-    # @return [void] This method does not return a value; it performs side effects such as displaying the summary and
-    # exporting to CSV if specified.
-    #
-    # @example Generate a summary for today
-    #   summary('today')
-    #
-    # @example Generate a summary for a specific tag
-    #   summary(nil, 'work')
-    #
-    # @example Generate a summary for a date range and export to CSV
-    #   summary('2023-01-01..2023-01-31', nil, csv: 'summary.csv')
-    #
-    # @note The method initializes a `TimeReport` object with the database, time_scope, tag, and optional CSV filename.
-    # @note The method calls `display` on the `TimeReport` object to show the summary.
-    # @note If a CSV filename is provided and there are items to export, the method calls `export_csv` to export the
-    # summary to a CSV file.
-    # @note If no items are found to export, it prints a message indicating that no items were found.
+    # @return [void] This method does not return a value; it performs side effects such as displaying
+    # and exporting the report.
     def summary(time_scope = nil, tag = nil)
-      csv_filename = options[:csv]&.split('.')&.first
-      ics_filename = options[:ics]&.split('.')&.first
-      report = TimeReport.new(@db, time_scope, tag, csv_filename, ics_filename)
-
-      report.display
-      items = report.items
-      if items.any?
-        report.export_csv if csv_filename
-        report.export_icalendar if ics_filename
-      elsif items.empty?
-        puts 'No items found to export'
-      end
+      options = build_options(time_scope, tag)
+      report = TimeReport.new(@db, options)
+      display_and_export_report(report, options)
     end
 
     desc 'edit (e) [id] [field] [value]',

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -36,8 +36,9 @@ module Timet
     VALID_STATUSES_FOR_INSERTION = %i[no_items complete].freeze
 
     desc "start [tag] --notes='' --pomodoro=[min]",
-         'Starts tracking time for a task labeled with the provided [tag],  notes and "pomodoro time" in minutes
-         (optional).'
+         'Start time tracking for a task labeled with the provided [tag], notes and "pomodoro time"
+        in minutes (optional).
+        tt start project1 "Starting project1" --pomodoro=25'
     option :notes, type: :string, desc: 'Add a note'
     option :pomodoro, type: :numeric, desc: 'Pomodoro time in minutes'
     # Starts a new tracking session with the given tag and optional notes.
@@ -76,7 +77,7 @@ module Timet
       summary
     end
 
-    desc 'stop', 'stop time tracking'
+    desc 'stop', 'Stop time tracking'
     # Stops the current tracking session if there is one in progress.
     #
     # @return [void] This method does not return a value; it performs side effects such as updating the tracking item
@@ -99,7 +100,7 @@ module Timet
       summary unless display
     end
 
-    desc 'resume (r) [id]', 'resume last task'
+    desc 'resume (r) [id]', 'Resume last task (id is an optional parameter) => tt resume'
     # Resumes the last tracking session if it was completed.
     #
     # @return [void] This method does not return a value; it performs side effects such as resuming a tracking session
@@ -131,9 +132,15 @@ module Timet
       end
     end
 
-    desc 'summary (su) [time_scope] [tag] --csv=csv_filename',
-         '[time_scope] => [today (t), yesterday (y), week (w), month (m), [start_date]..[end_date]]  [tag]'
-    option :csv, type: :string, desc: 'Export to CSV file'
+    desc 'summary (su) [time_scope] [tag] --csv=csv_filename --ics=ics_filename',
+         'Display a summary of tracked time and export to CSV.
+          [time_scope] => [today (t), yesterday (y), week (w), month (m). => tt su yesterday
+          [start_date]..[end_date]] => tt su 2024-10-03..2024-10-20
+          [tag] => tt su Task1
+          --csv=csv_filename => tt su month --csv=myfile
+          --ics=ics_filename => tt su week --csv=mycalendar'
+    option :csv, type: :string, desc: 'Export to CSV'
+    option :ics, type: :string, desc: 'Export to iCalendar'
     # Generates a summary of tracking items based on the provided time_scope and tag, and optionally exports the summary
     # to a CSV file.
     #
@@ -172,7 +179,9 @@ module Timet
     end
 
     desc 'edit (e) [id] [field] [value]',
-         'edit a task, [field] (notes, tag, start or end) and [value] are optional parameters'
+         'Edit task, [field] (notes, tag, start or end) and [value] are optional parameters.
+          Update notes => tt edit 12 notes "Update note"
+          Update start time => tt edit 12 start 12:33'
     # Edits a specific tracking item by its ID, allowing the user to modify fields such as notes, tag, start time, or
     # end time.
     #
@@ -211,7 +220,7 @@ module Timet
       display_item(updated_item || item)
     end
 
-    desc 'delete (d) [id]', 'delete a task'
+    desc 'delete (d) [id]', 'Delete task => tt d 23'
     # Deletes a specific tracking item by its ID after confirming with the user.
     #
     # @param id [Integer] The ID of the tracking item to be deleted.
@@ -238,7 +247,7 @@ module Timet
       delete_item_and_print_message(id, "Deleted #{id}")
     end
 
-    desc 'cancel (c)', 'cancel active time tracking'
+    desc 'cancel (c)', 'Cancel active time tracking => tt c'
     # Cancels the active time tracking session by deleting the last tracking item.
     #
     # @return [void] This method does not return a value; it performs side effects such as deleting the active tracking

--- a/lib/timet/application_helper.rb
+++ b/lib/timet/application_helper.rb
@@ -184,5 +184,49 @@ module Timet
       tag, notes = item.values_at(Application::FIELD_INDEX['tag'], Application::FIELD_INDEX['notes'])
       start(tag, notes)
     end
+
+    # Builds a hash of options to be used when initializing a TimeReport instance.
+    #
+    # @param time_scope [String, nil] The filter to apply when fetching items. Possible values include 'today',
+    #   'yesterday', 'week', 'month', or a date range in the format 'YYYY-MM-DD..YYYY-MM-DD'.
+    # @param tag [String, nil] The tag to filter the items by.
+    #
+    # @return [Hash] A hash containing the filter, tag, CSV filename, and iCalendar filename.
+    #
+    # @example Build options with a filter and tag
+    #   build_options('today', 'work') # => { filter: 'today', tag: 'work', csv: nil, ics: nil }
+    def build_options(time_scope, tag)
+      csv_filename = options[:csv]&.split('.')&.first
+      ics_filename = options[:ics]&.split('.')&.first
+      {
+        filter: time_scope,
+        tag: tag,
+        csv: csv_filename,
+        ics: ics_filename
+      }
+    end
+
+    # Displays the report and exports it to a CSV file and/or an iCalendar file if specified.
+    #
+    # @param report [TimeReport] The TimeReport instance to display and export.
+    # @param options [Hash] A hash containing the options for exporting the report.
+    # @option options [String, nil] :csv The filename to use when exporting the report to CSV.
+    # @option options [String, nil] :ics The filename to use when exporting the report to iCalendar.
+    #
+    # @return [void] This method does not return a value; it performs side effects such as displaying
+    # and exporting the report.
+    #
+    # @example Display and export the report to CSV and iCalendar
+    #   display_and_export_report(report, { csv: 'report.csv', ics: 'icalendar.ics' })
+    def display_and_export_report(report, options)
+      report.display
+      items = report.items
+      if items.any?
+        report.export_csv if options[:csv]
+        report.export_icalendar if options[:ics]
+      elsif items.empty?
+        puts 'No items found to export'
+      end
+    end
   end
 end

--- a/lib/timet/application_helper.rb
+++ b/lib/timet/application_helper.rb
@@ -206,6 +206,29 @@ module Timet
       }
     end
 
+    # @note This class is responsible for exporting reports to CSV and iCalendar formats.
+    class ReportExporter
+      # Exports the report to a CSV file if the `csv` option is provided.
+      #
+      # @param report [TimeReport] The report object to export.
+      # @param options [Hash] The options hash containing export settings.
+      # @option options [String] :csv The filename to use when exporting the report to CSV.
+      # @return [void]
+      def self.export_csv_report(report, options)
+        report.export_csv if options[:csv]
+      end
+
+      # Exports the report to an iCalendar file if the `ics` option is provided.
+      #
+      # @param report [TimeReport] The report object to export.
+      # @param options [Hash] The options hash containing export settings.
+      # @option options [String] :ics The filename to use when exporting the report to iCalendar.
+      # @return [void]
+      def self.export_icalendar_report(report, options)
+        report.export_icalendar if options[:ics]
+      end
+    end
+
     # Displays the report and exports it to a CSV file and/or an iCalendar file if specified.
     #
     # @param report [TimeReport] The TimeReport instance to display and export.
@@ -220,11 +243,20 @@ module Timet
     #   display_and_export_report(report, { csv: 'report.csv', ics: 'icalendar.ics' })
     def display_and_export_report(report, options)
       report.display
+      export_report(report, options)
+    end
+
+    # Exports the given report in CSV and iCalendar formats if there are items, otherwise prints a message.
+    #
+    # @param report [Report] The report to be exported.
+    # @param options [Hash] The options to pass to the exporter.
+    # @return [void]
+    def export_report(report, options)
       items = report.items
       if items.any?
-        report.export_csv if options[:csv]
-        report.export_icalendar if options[:ics]
-      elsif items.empty?
+        ReportExporter.export_csv_report(report, options)
+        ReportExporter.export_icalendar_report(report, options)
+      else
         puts 'No items found to export'
       end
     end

--- a/lib/timet/time_report.rb
+++ b/lib/timet/time_report.rb
@@ -24,7 +24,7 @@ module Timet
     attr_reader :items
 
     # Provides access to the CSV filename.
-    attr_reader :filename
+    attr_reader :csv_filename
 
     # Initializes a new instance of the TimeReport class.
     #
@@ -38,10 +38,11 @@ module Timet
     # instance variables.
     #
     # @example Initialize a new TimeReport instance with a filter and tag
-    #   TimeReport.new(db, 'today', 'work', 'report.csv')
-    def initialize(db, filter = nil, tag = nil, csv = nil)
+    #   TimeReport.new(db, 'today', 'work', 'report.csv', 'icalendar.ics')
+    def initialize(db, filter = nil, tag = nil, csv = nil, ics = nil)
       @db = db
-      @filename = csv
+      @csv_filename = csv
+      @ics_file = ics
       @filter = formatted_filter(filter)
       @items = filter ? filter_items(@filter, tag) : @db.all_items
     end
@@ -94,11 +95,11 @@ module Timet
     # @return [void] This method does not return a value; it performs side effects such as writing the CSV file.
     #
     # @example Export the report to a CSV file
-    #   time_report.export_sheet
+    #   time_report.export_csv
     #
     # @note The method writes the items to a CSV file and prints a confirmation message.
-    def export_sheet
-      file_name = "#{filename}.csv"
+    def export_csv
+      file_name = "#{csv_filename}.csv"
       write_csv(file_name)
 
       puts "The #{file_name} has been exported."

--- a/lib/timet/version.rb
+++ b/lib/timet/version.rb
@@ -6,6 +6,6 @@ module Timet
   # @return [String] The version number in the format 'major.minor.patch'.
   #
   # @example Get the version of the Timet application
-  #   Timet::VERSION # => '1.4.2'
-  VERSION = '1.4.2'
+  #   Timet::VERSION # => '1.4.3'
+  VERSION = '1.4.3'
 end

--- a/spec/timet/application_spec.rb
+++ b/spec/timet/application_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Timet::Application do
 
     allow(Timet::TimeReport).to receive(:new).and_return(time_report)
     allow(time_report).to receive(:display)
-    allow(time_report).to receive(:export_sheet)
+    allow(time_report).to receive(:export_csv)
     allow(time_report).to receive(:show_row)
     allow(time_report).to receive(:items).and_return(['item'])
   end
@@ -235,7 +235,7 @@ RSpec.describe Timet::Application do
       it 'exports the summary to the given csv filename' do
         app.options = { csv: 'output.csv' }
         app.summary
-        expect(time_report).to have_received(:export_sheet)
+        expect(time_report).to have_received(:export_csv)
       end
     end
 

--- a/spec/timet/time_report_spec.rb
+++ b/spec/timet/time_report_spec.rb
@@ -3,7 +3,8 @@
 RSpec.describe Timet::TimeReport do
   let(:db) { instance_double(Timet::Database) }
   let(:items) { [] }
-  let(:time_report) { described_class.new(db, filter, tag, csv, ics) }
+  let(:options) { { filter: filter, tag: tag, csv: csv, ics: ics } }
+  let(:time_report) { described_class.new(db, options) }
   let(:filter) { nil }
   let(:tag) { nil }
   let(:csv) { nil }

--- a/spec/timet/time_report_spec.rb
+++ b/spec/timet/time_report_spec.rb
@@ -3,10 +3,11 @@
 RSpec.describe Timet::TimeReport do
   let(:db) { instance_double(Timet::Database) }
   let(:items) { [] }
-  let(:time_report) { described_class.new(db, filter, tag, csv) }
+  let(:time_report) { described_class.new(db, filter, tag, csv, ics) }
   let(:filter) { nil }
   let(:tag) { nil }
   let(:csv) { nil }
+  let(:ics) { nil }
 
   before do
     allow(db).to receive_messages(all_items: items, execute_sql: [])


### PR DESCRIPTION
### Description:
This PR addresses various enhancements, refactorings, and bug fixes to the Time Report application. The main changes include updates to gem dependencies, the addition of iCalendar export functionality, improved command descriptions, and enhancements to the Time Report initialization and export methods.

---
### Improvements:
- [x] **Refactor export logic**: Introduced a new `ReportExporter` class to handle the export of reports to CSV and iCalendar formats, addressing the Feature Envy code smell and making the `ApplicationHelper` module more modular.
- [x] **Update gem dependencies**: Updated several gems to their latest versions, including `icalendar`, `sqlite3`, `json`, `parser`, `rubocop`, and `rubocop-ast`.
- [x] **Refactor `TimeReport` initialization**: Refactored `TimeReport` initialization to use an options hash instead of individual parameters, and added support for exporting tracking summaries to iCalendar format.
- [x] **Enhance command descriptions**: Improved the descriptions of the `start`, `stop`, `resume`, `summary`, `edit`, `delete`, and `cancel` commands, and added an `--ics` option to the `summary` command for iCalendar export.
- [x] **Add `icalendar` gem**: Added the `icalendar` gem to support iCalendar functionality and updated the `timet` gem version to `1.4.3`.

---
### Bug fixes:
* Corrected platform names in the lockfile.
* Updated the `TimeReport` spec to use the new options hash in the `TimeReport` initialization.

---
#### Tasks:
- [x] Move export logic to `ReportExporter` class.
- [x] Update `export_report` method to use `ReportExporter` class.
- [x] Add Yardoc comments for `ReportExporter` class and `export_report` method.
- [x] Update gem dependencies and lockfile.
- [x] Refactor `TimeReport` initialization and add iCalendar export functionality.
- [x] Refactor `TimeReport` to support iCalendar export and update related methods.
- [x] Enhance command descriptions and add iCalendar export option.
- [x] Add `icalendar` gem and update `Timet` version to `1.4.3`.


### Additional Considerations:

* This PR assumes that the `icalendar` gem is installed and configured correctly.
* It is recommended to review the updated command descriptions and ensure they are accurate and helpful for users.
* The PR does not include changes to the user interface or any non-code files.