### PR TITLE
Fix/icalendar issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## [Unreleased]
 
+## [1.4.5] - 2024-11-18
+
+**Improvements:**
+- Added `base64` gem to the Gemfile to ensure compatibility with Ruby 3.4.0.
+- Updated the `json` gem from version 2.8.1 to 2.8.2.
+- Updated the `rubocop-ast` gem from version 1.35.0 to 1.36.1.
+- Added the `icalendar` gem to the application.
+
+**Bug Fixes:**
+- Fixed the deprecation warning related to `base64` being removed from the Ruby standard library in Ruby 3.4.0.
+
+
 ## [1.4.4] - 2024-11-12
 
 **Improvements:**

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'base64', '~> 0.2.0'
 gem 'csv', '~> 3.3.0'
 gem 'descriptive_statistics', '~> 2.5'
 gem 'icalendar', '~> 2.10.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    base64 (0.2.0)
     csv (3.3.0)
     descriptive_statistics (2.5.1)
     diff-lcs (1.5.1)
@@ -102,6 +103,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  base64 (~> 0.2.0)
   csv (~> 3.3.0)
   descriptive_statistics (~> 2.5)
   icalendar (~> 2.10.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timet (1.4.4)
+    timet (1.4.5)
       sqlite3 (~> 2, >= 1.7)
       thor (~> 1.2)
       tty-prompt (~> 0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       ice_cube (~> 0.16)
       ostruct
     ice_cube (0.17.0)
-    json (2.8.1)
+    json (2.8.2)
     language_server-protocol (3.17.0.3)
     ostruct (0.6.1)
     parallel (1.26.3)
@@ -54,7 +54,7 @@ GEM
       rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.35.0)
+    rubocop-ast (1.36.1)
       parser (>= 3.3.1.0)
     rubocop-rspec (3.2.0)
       rubocop (~> 1.61)

--- a/lib/timet/application.rb
+++ b/lib/timet/application.rb
@@ -3,6 +3,7 @@
 require_relative 'version'
 require 'thor'
 require 'tty-prompt'
+require 'icalendar'
 require_relative 'validation_edit_helper'
 require_relative 'application_helper'
 require_relative 'time_helper'

--- a/lib/timet/version.rb
+++ b/lib/timet/version.rb
@@ -6,6 +6,6 @@ module Timet
   # @return [String] The version number in the format 'major.minor.patch'.
   #
   # @example Get the version of the Timet application
-  #   Timet::VERSION # => '1.4.4'
-  VERSION = '1.4.4'
+  #   Timet::VERSION # => '1.4.5'
+  VERSION = '1.4.5'
 end


### PR DESCRIPTION
### Description:
This pull request addresses compatibility issues with Ruby 3.4.0 by adding the `base64` gem and updating other dependencies. The changes ensure that the application remains functional and free from deprecation warnings.

---
### Improvements:
- [x] Added `base64` gem to the Gemfile to ensure compatibility with Ruby 3.4.0.
- [x] Updated the `json` gem from version 2.8.1 to 2.8.2.
- [x] Updated the `rubocop-ast` gem from version 1.35.0 to 1.36.1.
- [x] Added the `icalendar` gem to the application.

---
### Bug fixes:
- [x] Fixed the deprecation warning related to `base64` being removed from the Ruby standard library in Ruby 3.4.0.

---
#### Tasks:
- [x] Updated Gemfile.lock to reflect the new dependencies.
- [x] Added `icalendar` to the list of required gems in `lib/timet/application.rb`.

### Additional Considerations:
- Ensure that all tests pass after these dependency updates.
- Monitor for any potential issues arising from the updated gems.
- Notify the author of the `icalendar` gem to update their gemspec to include `base64` as a dependency.