### PR TITLE
Fix/beginning of day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Extracted the logic for syncing items by ID into a separate method `sync_items_by_id` for better readability and maintainability.
 - Improved the writing of missing environment variables to the .env file in the S3Supabase module by ensuring the file content ends with a newline character.
 - Refactored the `all_items` method to use `beginning_of_day` for today's timestamp, improving the accuracy of the timestamp calculation.
+- Fix `beginning_of_day`
 
 **Bug Fixes:**
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timet (1.5.1)
+    timet (1.5.1.1)
       aws-sdk-s3 (~> 1.171)
       descriptive_statistics (~> 2)
       dotenv (~> 3)

--- a/lib/timet/database.rb
+++ b/lib/timet/database.rb
@@ -187,7 +187,7 @@ module Timet
     # @note The method executes SQL to fetch all items from the 'items' table that have a start time greater than
     # or equal to today.
     def all_items
-      today = Time.now.beginning_of_day.to_i
+      today = TimeHelper.beginning_of_day.to_i
       execute_sql('SELECT * FROM items WHERE start >= ? AND (deleted IS NULL OR deleted = 0) ORDER BY start DESC',
                   [today])
     end

--- a/lib/timet/time_helper.rb
+++ b/lib/timet/time_helper.rb
@@ -232,5 +232,20 @@ module Timet
       end
       hour_blocks
     end
+
+    # Returns a Time object representing the start of the given day (midnight).
+    #
+    # @param time [Time] The time for which to find the beginning of day (defaults to current time).
+    # @return [Time] A new Time object set to midnight (00:00:00) of the given day.
+    #
+    # @example Get beginning of current day
+    #   TimeHelper.beginning_of_day # => 2024-12-07 00:00:00
+    #
+    # @example Get beginning of specific day
+    #   time = Time.new(2024, 12, 7, 15, 30, 45)
+    #   TimeHelper.beginning_of_day(time) # => 2024-12-07 00:00:00
+    def self.beginning_of_day(time = Time.now)
+      Time.new(time.year, time.month, time.day)
+    end
   end
 end

--- a/lib/timet/version.rb
+++ b/lib/timet/version.rb
@@ -6,6 +6,6 @@ module Timet
   # @return [String] The version number in the format 'major.minor.patch'.
   #
   # @example Get the version of the Timet application
-  #   Timet::VERSION # => '1.5.1'
-  VERSION = '1.5.1'
+  #   Timet::VERSION # => '1.5.1.1'
+  VERSION = '1.5.1.1'
 end


### PR DESCRIPTION
### Description:
This pull request includes several refactorings and improvements to enhance code readability, maintainability, and fix a parameter list issue. The changes are summarized below.

---
### Improvements:
- [x] Refactored the `all_items` method in the `database.rb` file to use `TimeHelper.beginning_of_day` for calculating the start of the day.
- [x] Added a new method `beginning_of_day` to the `TimeHelper` module to encapsulate the logic for finding the start of a given day.
---
### Bug fixes:
- [x] Fixed the issue of having parameter lists longer than 5 parameters by refactoring the method to use a hash for named parameters.
- [x] Fixed the `beginning_of_day` method and added a note to the CHANGELOG about the fix.
---
#### Tasks:
- [x] Update the version of the `timet` gem to 1.5.1.1 in the Gemfile.lock and version.rb files.
- [x] Add a note to the CHANGELOG about fixing the `beginning_of_day` method.